### PR TITLE
一時的にprovenanceオプションを解除する

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,6 +37,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@chatwork'
       - run: npm ci
-      - run: npm publish --provenance --access public
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
レポジトリの公開範囲がまだ private なので、一時的に `--provenance` オプションを無効化する。
初期リリースが完了し次第、レポジトリを公開に変更する。その際に `--provenance` オプションを復活させる。