### PR TITLE
fix: add text content type to support Cursor 0.46.9

### DIFF
--- a/src/toolCallbacks.ts
+++ b/src/toolCallbacks.ts
@@ -39,7 +39,7 @@ function chatworkClientResponseToCallToolResult(
       content: [
         {
           type: 'text',
-          text: `Error: status code ${res.status}`,
+          text: `Error: ChatWork API returned status code ${res.status} for ${res.uri}`,
         },
         {
           type: 'resource',
@@ -54,6 +54,10 @@ function chatworkClientResponseToCallToolResult(
 
   return {
     content: [
+      {
+        type: 'text',
+        text: res.response,
+      },
       {
         type: 'resource',
         resource: {


### PR DESCRIPTION
# Cursor 0.46.9との互換性対応

## 概要
* Cursor 0.46.9でリソースタイプが非サポートとなり、エラーが発生していました。
* MCP仕様に基づき、`content`に`text`と`resource`の両方を含める実装を行いました。
* クライアント互換性を考慮し、テキスト形式を標準化しました。

## 実装内容
* `chatworkClientResponseToCallToolResult`関数を修正し、成功時レスポンスにも`text`タイプのコンテンツを含めるようにしました。
* エラーハンドリングを強化し、より詳細なエラー情報を提供するようにしました。

## 動作確認
* Lintチェックを実施しました。
* 型チェックを実施しました。
* テストを実施しました。

Link to Devin run: https://app.devin.ai/sessions/d6623a23c01c4e4681b59e99bb0f066b
User: Hiroshi Tanaka
