### PR TITLE
`resources`の代わりに`text`で prompt message を渡す #25

### DIFF
--- a/src/toolCallbacks.ts
+++ b/src/toolCallbacks.ts
@@ -55,12 +55,16 @@ function chatworkClientResponseToCallToolResult(
   return {
     content: [
       {
+        type: 'text',
+        text: res.response,
+      },
+      {
         type: 'resource',
         resource: {
           uri: res.uri,
-          text: res.response,
+          text: 'Chatwork',
         },
-      },
+      }
     ],
   };
 }


### PR DESCRIPTION
Cursor や GitHub Copilot Agent など`Content type "resource" not supported` な client 向けに、
prompt message を`text`で渡すように変更。

refs: https://modelcontextprotocol.io/specification/2025-03-26/server/prompts#embedded-resources