### PR TITLE
`gemini-2.5-pro-exp-03-25-max`とのスキーマ互換性を修正

### DIFF
--- a/src/chatworkClient.ts
+++ b/src/chatworkClient.ts
@@ -1,8 +1,8 @@
 interface ChatworkClientRequest {
   path: string;
   method: 'GET' | 'POST' | 'PUT' | 'DELETE';
-  query: Record<string, string | number | undefined>;
-  body: Record<string, string | number | undefined>;
+  query: Record<string, string | number | null | undefined>;
+  body: Record<string, string | number | null | undefined>;
 }
 
 export interface ChatworkClientResponse {

--- a/src/chatworkClient.ts
+++ b/src/chatworkClient.ts
@@ -1,8 +1,8 @@
 interface ChatworkClientRequest {
   path: string;
   method: 'GET' | 'POST' | 'PUT' | 'DELETE';
-  query: Record<string, string | number | null | undefined>;
-  body: Record<string, string | number | null | undefined>;
+  query: Record<string, string | number | undefined>;
+  body: Record<string, string | number | undefined>;
 }
 
 export interface ChatworkClientResponse {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,237 +1,415 @@
 import { z } from 'zod';
 
-export const listMyTasksParamsSchema = z.object({
-  query: z.object({
-    assigned_by_account_id: z.number(),
-    status: z.union([z.literal('open'), z.literal('done')]),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/get-my-tasks */
+export const listMyTasksParamsSchema = z
+  .object({
+    query: z.object({
+      assigned_by_account_id: z
+        .number()
+        .int()
+        .optional()
+        .describe('タスクの依頼者のアカウントID'),
+      status: z
+        .enum(['open', 'done'])
+        .optional()
+        .describe('タスクのステータス（open: 未完了, done: 完了）'),
+    }),
+  })
+  .describe('自分のタスク一覧取得');
 
-export const createRoomParamsSchema = z.object({
-  body: z.object({
-    name: z.string(),
-    description: z.string().optional(),
-    link: z.union([z.literal(0), z.literal(1), z.null()]).optional(),
-    link_code: z.string().optional(),
-    link_need_acceptance: z
-      .union([z.literal(0), z.literal(1), z.null()])
-      .optional(),
-    members_admin_ids: z.string(),
-    members_member_ids: z.string().optional(),
-    members_readonly_ids: z.string().optional(),
-    icon_preset: z.string().optional(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/post-rooms */
+export const createRoomParamsSchema = z
+  .object({
+    body: z.object({
+      name: z.string().min(1).max(255).describe('グループチャット名'),
+      description: z.string().optional().describe('グループチャットの説明'),
+      link: z
+        .number()
+        .int()
+        .min(0)
+        .max(1)
+        .default(0)
+        .describe('招待リンクを作成するかどうか (0: 作成しない, 1: 作成する)'),
+      link_code: z
+        .string()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe('招待リンクのリンクコード'),
+      link_need_acceptance: z
+        .number()
+        .int()
+        .min(0)
+        .max(1)
+        .default(1)
+        .describe('承認要否 (0: 不要, 1: 必要)'),
+      members_admin_ids: z
+        .string()
+        .describe('管理者権限のユーザーのID (カンマ区切り)'),
+      members_member_ids: z
+        .string()
+        .optional()
+        .describe('メンバー権限のユーザーのID (カンマ区切り)'),
+      members_readonly_ids: z
+        .string()
+        .optional()
+        .describe('閲覧のみ権限のユーザーのID (カンマ区切り)'),
+      icon_preset: z
+        .string()
+        .optional()
+        .describe('グループチャットのアイコンプリセット'),
+    }),
+  })
+  .describe('新規グループチャット作成');
 
-export const getRoomParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/get-rooms-room_id */
+export const getRoomParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+  })
+  .describe('チャット情報取得');
 
-export const updateRoomParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-  body: z.object({
-    name: z.string().optional(),
-    description: z.string().optional(),
-    icon_preset: z.string().optional(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/put-rooms-room_id */
+export const updateRoomParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+    body: z.object({
+      name: z
+        .string()
+        .min(1)
+        .max(255)
+        .optional()
+        .describe('グループチャット名'),
+      description: z.string().optional().describe('グループチャットの説明'),
+      icon_preset: z
+        .string()
+        .optional()
+        .describe('グループチャットのアイコンプリセット'),
+    }),
+  })
+  .describe('チャット情報更新');
 
-export const deleteOrLeaveRoomParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-  body: z.object({
-    action_type: z.union([z.literal('leave'), z.literal('delete')]),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/delete-rooms-room_id */
+export const deleteOrLeaveRoomParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+    body: z.object({
+      action_type: z
+        .enum(['leave', 'delete'])
+        .describe('操作の種類 (leave: 退席, delete: 削除)'),
+    }),
+  })
+  .describe('グループチャット退席/削除');
 
-export const listRoomMembersParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/get-rooms-room_id-members */
+export const listRoomMembersParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+  })
+  .describe('チャットメンバー一覧取得');
 
-export const updateRoomMembersParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-  body: z.object({
-    members_admin_ids: z.string(),
-    members_member_ids: z.string().optional(),
-    members_readonly_ids: z.string().optional(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/put-rooms-room_id-members */
+export const updateRoomMembersParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+    body: z.object({
+      members_admin_ids: z
+        .string()
+        .describe('管理者権限のユーザーのID (カンマ区切り)'),
+      members_member_ids: z
+        .string()
+        .optional()
+        .describe('メンバー権限のユーザーのID (カンマ区切り)'),
+      members_readonly_ids: z
+        .string()
+        .optional()
+        .describe('閲覧のみ権限のユーザーのID (カンマ区切り)'),
+    }),
+  })
+  .describe('チャットメンバー一括変更');
 
-export const listRoomMessagesParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-  query: z.object({
-    force: z.union([z.literal(0), z.literal(1), z.null()]).optional(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/get-rooms-room_id-messages */
+export const listRoomMessagesParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+    query: z.object({
+      force: z
+        .number()
+        .int()
+        .min(0)
+        .max(1)
+        .default(0)
+        .describe(
+          '未読にかかわらず最新の100件を取得するか (0: しない, 1: する)',
+        ),
+    }),
+  })
+  .describe('チャットメッセージ一覧取得');
 
-export const postRoomMessageParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-  body: z.object({
-    body: z.string(),
-    self_unread: z.union([z.literal(0), z.literal(1), z.null()]).optional(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/post-rooms-room_id-messages */
+export const postRoomMessageParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+    body: z.object({
+      body: z.string().describe('メッセージ本文'),
+      self_unread: z
+        .number()
+        .int()
+        .min(0)
+        .max(1)
+        .default(0)
+        .describe('自分自身を未読にするか (0: しない, 1: する)'),
+    }),
+  })
+  .describe('チャットメッセージ投稿');
 
-export const readRoomMessagesParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-  body: z.object({
-    message_id: z.string(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/put-rooms-room_id-messages-read */
+export const readRoomMessagesParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+    body: z.object({
+      message_id: z.string().optional().describe('既読にするメッセージID'),
+    }),
+  })
+  .describe('チャットメッセージ既読化');
 
-export const unreadRoomMessageParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-  body: z.object({
-    message_id: z.string(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/put-rooms-room_id-messages-unread */
+export const unreadRoomMessageParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+    body: z.object({
+      message_id: z.string().describe('未読にするメッセージID'),
+    }),
+  })
+  .describe('チャットメッセージ未読化');
 
-export const getRoomMessageParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-    message_id: z.string(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/get-rooms-room_id-messages-message_id */
+export const getRoomMessageParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+      message_id: z.string().describe('メッセージID'),
+    }),
+  })
+  .describe('チャットメッセージ取得');
 
-export const updateRoomMessageParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-    message_id: z.string(),
-  }),
-  body: z.object({
-    body: z.string(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/put-rooms-room_id-messages-message_id */
+export const updateRoomMessageParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+      message_id: z.string().describe('メッセージID'),
+    }),
+    body: z.object({
+      body: z.string().describe('更新後のメッセージ本文'),
+    }),
+  })
+  .describe('チャットメッセージ更新');
 
-export const deleteRoomMessageParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-    message_id: z.string(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/delete-rooms-room_id-messages-message_id */
+export const deleteRoomMessageParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+      message_id: z.string().describe('メッセージID'),
+    }),
+  })
+  .describe('チャットメッセージ削除');
 
-export const listRoomTasksParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-  query: z.object({
-    account_id: z.number().optional(),
-    assigned_by_account_id: z.number().optional(),
-    status: z.union([z.literal('open'), z.literal('done')]).optional(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/get-rooms-room_id-tasks */
+export const listRoomTasksParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+    query: z.object({
+      account_id: z
+        .number()
+        .int()
+        .optional()
+        .describe('タスクの担当者のアカウントID'),
+      assigned_by_account_id: z
+        .number()
+        .int()
+        .optional()
+        .describe('タスクの依頼者のアカウントID'),
+      status: z
+        .enum(['open', 'done'])
+        .optional()
+        .describe('タスクのステータス（open: 未完了, done: 完了）'),
+    }),
+  })
+  .describe('チャットタスク一覧取得');
 
-export const createRoomTaskParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-  body: z.object({
-    body: z.string(),
-    to_ids: z.string(),
-    limit: z.number().optional(),
-    limit_type: z
-      .union([z.literal('none'), z.literal('date'), z.literal('time')])
-      .optional(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/post-rooms-room_id-tasks */
+export const createRoomTaskParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+    body: z.object({
+      body: z.string().describe('タスクの内容'),
+      to_ids: z.string().describe('担当者のアカウントID (カンマ区切り)'),
+      limit: z.number().int().optional().describe('タスクの期限 (Unix time)'),
+      limit_type: z
+        .enum(['none', 'date', 'time'])
+        .optional()
+        .default('time')
+        .describe('タスクの期限種別 (none, date, time)'),
+    }),
+  })
+  .describe('チャットタスク作成');
 
-export const getRoomTaskParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-    task_id: z.number(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/get-rooms-room_id-tasks-task_id */
+export const getRoomTaskParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+      task_id: z.number().int().describe('タスクID'),
+    }),
+  })
+  .describe('チャットタスク情報取得');
 
-export const updateRoomTasksStatusParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-    task_id: z.number(),
-  }),
-  body: z.object({
-    body: z.union([z.literal('open'), z.literal('done')]),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/put-rooms-room_id-tasks-task_id-status */
+export const updateRoomTasksStatusParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+      task_id: z.number().int().describe('タスクID'),
+    }),
+    body: z.object({
+      body: z
+        .enum(['open', 'done'])
+        .describe('タスクのステータス（open: 未完了, done: 完了）'),
+    }),
+  })
+  .describe('チャットタスクステータス更新');
 
-export const listRoomFilesParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-  query: z.object({
-    account_id: z.number().optional(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/get-rooms-room_id-files */
+export const listRoomFilesParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+    query: z.object({
+      account_id: z
+        .number()
+        .int()
+        .optional()
+        .describe('アップロードしたユーザーのアカウントID'),
+    }),
+  })
+  .describe('チャットファイル一覧取得');
 
-export const getRoomFileParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-    file_id: z.number(),
-  }),
-  query: z.object({
-    create_download_url: z
-      .union([z.literal(0), z.literal(1), z.null()])
-      .optional(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/get-rooms-room_id-files-file_id */
+export const getRoomFileParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+      file_id: z.number().int().describe('ファイルID'),
+    }),
+    query: z.object({
+      create_download_url: z
+        .number()
+        .int()
+        .min(0)
+        .max(1)
+        .default(0)
+        .describe('ダウンロードURLを生成するか (0: しない, 1: する)'),
+    }),
+  })
+  .describe('チャットファイル情報取得');
 
-export const getRoomLinkParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/get-rooms-room_id-link */
+export const getRoomLinkParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+  })
+  .describe('チャット招待リンク取得');
 
-export const createRoomLinkParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-  body: z.object({
-    code: z.string().optional(),
-    need_acceptance: z.union([z.literal(0), z.literal(1), z.null()]).optional(),
-    description: z.string().optional(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/post-rooms-room_id-link */
+export const createRoomLinkParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+    body: z.object({
+      code: z.string().min(1).max(50).optional().describe('リンクコード'),
+      need_acceptance: z
+        .number()
+        .int()
+        .min(0)
+        .max(1)
+        .default(1)
+        .describe('承認要否 (0: 不要, 1: 必要)'),
+      description: z.string().optional().describe('リンクの説明'),
+    }),
+  })
+  .describe('チャット招待リンク作成');
 
-export const updateRoomLinkParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-  body: z.object({
-    code: z.string().optional(),
-    need_acceptance: z.union([z.literal(0), z.literal(1), z.null()]).optional(),
-    description: z.string().optional(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/put-rooms-room_id-link */
+export const updateRoomLinkParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+    body: z.object({
+      code: z.string().min(1).max(50).optional().describe('リンクコード'),
+      need_acceptance: z
+        .number()
+        .int()
+        .min(0)
+        .max(1)
+        .default(1)
+        .describe('承認要否 (0: 不要, 1: 必要)'),
+      description: z.string().optional().describe('リンクの説明'),
+    }),
+  })
+  .describe('チャット招待リンク更新');
 
-export const deleteRoomLinkParamsSchema = z.object({
-  path: z.object({
-    room_id: z.number(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/delete-rooms-room_id-link */
+export const deleteRoomLinkParamsSchema = z
+  .object({
+    path: z.object({
+      room_id: z.number().int().describe('ルームID'),
+    }),
+  })
+  .describe('チャット招待リンク削除');
 
-export const acceptIncomingRequestParamsSchema = z.object({
-  path: z.object({
-    request_id: z.number(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/put-incoming_requests-request_id */
+export const acceptIncomingRequestParamsSchema = z
+  .object({
+    path: z.object({
+      request_id: z.number().int().describe('承認依頼ID'),
+    }),
+  })
+  .describe('コンタクト承認依頼承認');
 
-export const rejectIncomingRequestParamsSchema = z.object({
-  path: z.object({
-    request_id: z.number(),
-  }),
-});
+/** @see https://developer.chatwork.com/reference/delete-incoming_requests-request_id */
+export const rejectIncomingRequestParamsSchema = z
+  .object({
+    path: z.object({
+      request_id: z.number().int().describe('承認依頼ID'),
+    }),
+  })
+  .describe('コンタクト承認依頼拒否');

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -11,9 +11,11 @@ export const createRoomParamsSchema = z.object({
   body: z.object({
     name: z.string(),
     description: z.string().optional(),
-    link: z.union([z.literal(0), z.literal(1)]).optional(),
+    link: z.union([z.literal(0), z.literal(1), z.null()]).optional(),
     link_code: z.string().optional(),
-    link_need_acceptance: z.union([z.literal(0), z.literal(1)]).optional(),
+    link_need_acceptance: z
+      .union([z.literal(0), z.literal(1), z.null()])
+      .optional(),
     members_admin_ids: z.string(),
     members_member_ids: z.string().optional(),
     members_readonly_ids: z.string().optional(),
@@ -69,7 +71,7 @@ export const listRoomMessagesParamsSchema = z.object({
     room_id: z.number(),
   }),
   query: z.object({
-    force: z.union([z.literal(0), z.literal(1)]).optional(),
+    force: z.union([z.literal(0), z.literal(1), z.null()]).optional(),
   }),
 });
 
@@ -79,7 +81,7 @@ export const postRoomMessageParamsSchema = z.object({
   }),
   body: z.object({
     body: z.string(),
-    self_unread: z.union([z.literal(0), z.literal(1)]).optional(),
+    self_unread: z.union([z.literal(0), z.literal(1), z.null()]).optional(),
   }),
 });
 
@@ -182,7 +184,9 @@ export const getRoomFileParamsSchema = z.object({
     file_id: z.number(),
   }),
   query: z.object({
-    create_download_url: z.union([z.literal(0), z.literal(1)]).optional(),
+    create_download_url: z
+      .union([z.literal(0), z.literal(1), z.null()])
+      .optional(),
   }),
 });
 
@@ -198,7 +202,7 @@ export const createRoomLinkParamsSchema = z.object({
   }),
   body: z.object({
     code: z.string().optional(),
-    need_acceptance: z.union([z.literal(0), z.literal(1)]).optional(),
+    need_acceptance: z.union([z.literal(0), z.literal(1), z.null()]).optional(),
     description: z.string().optional(),
   }),
 });
@@ -209,7 +213,7 @@ export const updateRoomLinkParamsSchema = z.object({
   }),
   body: z.object({
     code: z.string().optional(),
-    need_acceptance: z.union([z.literal(0), z.literal(1)]).optional(),
+    need_acceptance: z.union([z.literal(0), z.literal(1), z.null()]).optional(),
     description: z.string().optional(),
   }),
 });


### PR DESCRIPTION
- 型定義に由来する以下の問題を修正
> The argument schema for tool mcp_chatwork_create_room", is incompatible with gemini-2.5-pro-exp-03-25-max. Please fix the MCP server, disable the MCP server, or switch models.
- validation ルールを追加
- 各フィールドの説明文を追加