### PR TITLE
bump up 0.0.4-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chatwork/mcp-server",
-  "version": "0.0.2",
+  "version": "0.0.4-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chatwork/mcp-server",
-      "version": "0.0.2",
+      "version": "0.0.4-alpha",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatwork/mcp-server",
-  "version": "0.0.2",
+  "version": "0.0.4-alpha",
   "bin": "dist/index.js",
   "files": [
     "dist"


### PR DESCRIPTION
released 0.0.3
https://github.com/chatwork/chatwork-mcp-server/releases/tag/0.0.3

開発ブランチのバージョンは次バージョンのalphaとする。

https://github.com/chatwork/chatwork-mcp-server/compare/0.0.3..bump-up-0.0.4-alpha

