### PR TITLE
chore(dep): dependabotで @types/node のメジャーアップデートのPRを送って来ないようにする

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps): update'
+    ignore:
+      - dependency-name: '@types/node'
+        update-types:
+          - version-update:semver-major
     labels:
       - 'dependencies'
       - 'dependabot'


### PR DESCRIPTION
# 背景

`@types/node` へのアップデートPRがdependabotからくるがnode 24系のものである。24系の型定義ファイルを利用している場合、24でしか使えないAPIを利用したときにコンパイルエラーにならずnode22系で使えなくなる恐れがあるためアップデートしたくない。そのため、24系へのアップデートが来ないように修正を行う。

#変更内容

dependabot.yamlに@types/nodeに対してメジャーアップデートを無視するように設定をおこなった。